### PR TITLE
Add missing licence

### DIFF
--- a/packages/frontend-acceptance-tests/src/features/1 - 1 and 8 Day Licences/1_adult_1_or_8_day_licence_immediate_start.feature
+++ b/packages/frontend-acceptance-tests/src/features/1 - 1 and 8 Day Licences/1_adult_1_or_8_day_licence_immediate_start.feature
@@ -25,7 +25,7 @@ Feature: I want to buy a 1 or 8 day licence adult fishing licence
       | 8dayLicence    | No       | Adult     | Licence  | 3       | SN153PG  | 100121002711 | Now      | coarse2    |email@gmail.com         |             |               |
       | 8dayLicence    | No       | Adult     | Licence  | 3       | SN153PG  | 100121002711 | Now      | salmon    |                         | 07000900900 |email@gmail.com|
       | 1dayLicence    | No       | Adult     | Licence  | 3       | SN153PG  | 100121002711 | Now      | salmon    |email@gmail.com          |             |               |
-
+      | 1dayLicence    | No       | Adult     | Licence  | 3       | SN153PG  | 100121002711 | Now      | coarse2    |email@gmail.com         |             |               |
 
   Scenario Outline: Scenario 2 - Purchase Fishing Adult Licence 1 and 8 days - Future start date
     Given  I am at the start of the purchase journey


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2055

Only one licence type was not covered by the acceptance tests, a coarse
fishing 2 rod 1 day licence, so we need to add this