### PR TITLE
Update tests to match changed error on Ts&Cs

### DIFF
--- a/packages/frontend-acceptance-tests/src/features/3 - Negative Tests/1_adult_licence_12_NEG.feature
+++ b/packages/frontend-acceptance-tests/src/features/3 - Negative Tests/1_adult_licence_12_NEG.feature
@@ -177,7 +177,7 @@ Scenario: Scenario 10 - Contact Details Errors
     When I dont agree to the terms and conditions and I click continue
     Then I expect the terms and conditions page to show the following errors
       | ErrorMessage  |
-      | You have not agreed to the terms and conditions     |
+      | You have not agreed to the licence conditions     |
     And I agree to the terms and conditions and click continue
     And I enter payment details
     And I confirm payment details

--- a/packages/frontend-acceptance-tests/src/features/3 - Negative Tests/2_adult_licence_1_and_8_NEG.feature
+++ b/packages/frontend-acceptance-tests/src/features/3 - Negative Tests/2_adult_licence_1_and_8_NEG.feature
@@ -174,7 +174,7 @@ Feature: Buy a Fishing Licence - Error messages = 1 and 8 day journey
     When I dont agree to the terms and conditions and I click continue
     Then I expect the terms and conditions page to show the following errors
       | ErrorMessage  |
-      | You have not agreed to the terms and conditions     |
+      | You have not agreed to the licence conditions     |
     And I agree to the terms and conditions and click continue
     And I enter payment details
     And I confirm payment details


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-2584

The error message has changed on the Ts&Cs page, which is causing the acceptance tests to fail. We need to update the acceptance tests to match what's output.