### PR TITLE
Ignore fragments when matching page URLs

### DIFF
--- a/packages/frontend-acceptance-tests/src/pages/page.js
+++ b/packages/frontend-acceptance-tests/src/pages/page.js
@@ -17,11 +17,11 @@ class Page {
 
     const getPageUrl = async () => {
       let url = await browser.getUrl()
-      if (url.includes('?')) {
-        url = url.substr(0, url.indexOf('?'))
-      }
-      if (url.includes('#')) {
-        url = url.substr(0, url.indexOf('#'))
+      const charactersToIgnore = ['?', '#']
+      for (const characterToIgnore of charactersToIgnore) {
+        if (url.includes(characterToIgnore)) {
+          url = url.substr(0, url.indexOf(characterToIgnore))
+        }
       }
       return url
     }

--- a/packages/frontend-acceptance-tests/src/pages/page.js
+++ b/packages/frontend-acceptance-tests/src/pages/page.js
@@ -20,6 +20,9 @@ class Page {
       if (url.includes('?')) {
         url = url.substr(0, url.indexOf('?'))
       }
+      if (url.includes('#')) {
+        url = url.substr(0, url.indexOf('#'))
+      }
       return url
     }
     let currentUrl = await getPageUrl()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-3672

IWTF-3672 modified the URLs in the journey to often include an empty fragment. We need to account for this in the tests as well.