### PR TITLE
disable firefox

### DIFF
--- a/packages/frontend-acceptance-tests/conf/docker.conf.js
+++ b/packages/frontend-acceptance-tests/conf/docker.conf.js
@@ -9,14 +9,15 @@ exports.config = {
       'goog:chromeOptions': {
         args: ['--headless', '--disable-gpu', '--no-sandbox']
       }
-    },
-    {
-      browserName: 'firefox',
-      browserVersion: 'latest',
-      'moz:firefoxOptions': {
-        args: ['-headless']
-      }
     }
+    // ---- FIREFOX DISABLED TEMPORARILY ----
+    // {
+    //   browserName: 'firefox',
+    //   browserVersion: 'latest',
+    //   'moz:firefoxOptions': {
+    //     args: ['-headless']
+    //   }
+    // }
   ],
   // set to info, debug or trace for more info
   logLevel: 'warn',


### PR DESCRIPTION
Error: Couldn't find a matching firefox browser for tag "140.0a1" on platform "linux"

firefox tests are not running, disabling to allow chrome tests to pass