### PR TITLE
Update tests to use ES6

### DIFF
--- a/packages/frontend-acceptance-tests/src/pages/licence-type.js
+++ b/packages/frontend-acceptance-tests/src/pages/licence-type.js
@@ -1,10 +1,8 @@
-'use strict'
-
-const Page = require('./page')
-const { logger } = require('defra-logging-facade')
+import Page from './page.js'
+import { logger } from 'defra-logging-facade'
 
 class FishTypePage extends Page {
-  async setFishType (fishType) {
+  setFishType = async (fishType) => {
     logger.info(`Licence Type selected as: ${fishType}`)
     switch (fishType) {
       case 'coarse2':
@@ -16,4 +14,5 @@ class FishTypePage extends Page {
     }
   }
 }
-module.exports = new FishTypePage('/buy/licence-type')
+
+export default new FishTypePage('/buy/licence-type')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4718

Node 20 enforces strict handling of ES Modules and top-level await, so existing CommonJS patterns ( require(...) ) break.

ESM is the standardised module system in modern JavaScript and Node ecosystems. CommonJS is now considered legacy.

Without this, acceptance tests cant be upgraded to Node 20.