### PR TITLE
Pin test packages to current patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
   },
   "devDependencies": {
     "@ksmithut/prettier-standard": "0.1.7",
-    "eslint-plugin-chai-friendly": "^0.7.2",
-    "husky": "^8.0.3",
-    "lerna": "^7.3.0",
-    "lerna-update-wizard": "^1.1.2",
-    "standard": "^17.1.0"
+    "eslint-plugin-chai-friendly": "0.7.2",
+    "husky": "8.0.3",
+    "lerna": "7.3.0",
+    "lerna-update-wizard": "1.1.2",
+    "standard": "17.1.0"
   },
   "prettier": {
     "printWidth": 140

--- a/packages/frontend-acceptance-tests/package.json
+++ b/packages/frontend-acceptance-tests/package.json
@@ -26,19 +26,19 @@
     "local": "./node_modules/.bin/wdio ./conf/local.conf.js"
   },
   "dependencies": {
-    "@wdio/cli": "^8.32.3",
-    "@wdio/cucumber-framework": "^8.32.3",
-    "@wdio/junit-reporter": "^8.32.2",
-    "@wdio/local-runner": "^8.32.3",
-    "@wdio/spec-reporter": "^8.32.2",
-    "axe-core": "^4.8.1",
-    "chai": "^4.3.8",
+    "@wdio/cli": "8.32.3",
+    "@wdio/cucumber-framework": "8.32.3",
+    "@wdio/junit-reporter": "8.32.2",
+    "@wdio/local-runner": "8.32.3",
+    "@wdio/spec-reporter": "8.32.2",
+    "axe-core": "4.8.1",
+    "chai": "4.3.8",
     "defra-logging-facade": "git+https://github.com/DEFRA/defra-logging-facade.git#b11d97e",
-    "dynamics-web-api": "^1.7.3",
-    "json-to-csv": "^1.0.0",
-    "moment": "^2.29.0",
-    "simple-oauth2": "^4.1.0",
-    "wdio-timeline-reporter": "^5.1.4",
-    "webdriverio": "^8.32.3"
+    "dynamics-web-api": "1.7.3",
+    "json-to-csv": "1.0.0",
+    "moment": "2.29.0",
+    "simple-oauth2": "4.1.0",
+    "wdio-timeline-reporter": "5.1.4",
+    "webdriverio": "8.32.3"
   }
 }

--- a/packages/pocl-test-file-generator/package.json
+++ b/packages/pocl-test-file-generator/package.json
@@ -10,14 +10,14 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "commander": "^6.0.0",
-    "moment": "^2.27.0",
-    "xmlbuilder2": "^2.3.1"
+    "commander": "6.0.0",
+    "moment": "2.27.0",
+    "xmlbuilder2": "2.3.1"
   },
   "type": "module",
   "devDependencies": {
-    "chai": "^4.2.0",
-    "mocha": "^8.1.1",
-    "sinon": "^9.0.3"
+    "chai": "4.2.0",
+    "mocha": "8.1.1",
+    "sinon": "9.0.3"
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-4831

As a result of a string of recent NPM vulnerabilities, we have agreed to pin to specific patch versions in all our dependencies. This should avoid us accidentally pulling in a newly-launched vulnerable version.

This ticket removes ^ or ~ to make sure each version is pinned to the version specified.