### PR TITLE
Resolve apt-key removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
       "integrity": "sha512-G255aP4hhQ04hSQ1/JgiKNeTzRCuLgK220lJXkHubpu+f67os5LArhFNxZaUC/EVa/sloOT7Fo5tn8C5gy7iLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -677,7 +676,6 @@
       "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-29.0.0.tgz",
       "integrity": "sha512-6t3V7fFsLlyhLSj4FS+fPz22pPVcFhFZ3QOP7otFYmkhZ4g1ierj5pf7fxJWvEsI555hGatg+Iql6cqK93RFUg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cucumber/messages": "<=25"
       }
@@ -826,7 +824,6 @@
       "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-4.0.1.tgz",
       "integrity": "sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@cucumber/messages": ">=17.1.1"
       }
@@ -836,7 +833,6 @@
       "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-26.0.1.tgz",
       "integrity": "sha512-DIxSg+ZGariumO+Lq6bn4kOUIUET83A4umrnWmidjGFl8XxkBieUZtsmNbLYgH/gnsmP07EfxxdTr0hOchV1Sg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/uuid": "10.0.0",
         "class-transformer": "0.5.1",
@@ -3524,7 +3520,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -4816,7 +4811,6 @@
       "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-9.23.0.tgz",
       "integrity": "sha512-OmwPKV8c5ecLqo+EkytN7oUeYfNmRI4uOXGIR1ybP7AK5Zz+l9R0dGfoadEuwi1aZXAL0vwuhtq3p0OL3dfqHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.20.0"
       },
@@ -4883,7 +4877,6 @@
       "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
       "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
@@ -5193,7 +5186,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8587,7 +8579,6 @@
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1"
       },
@@ -8951,7 +8942,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9193,7 +9183,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9297,7 +9286,6 @@
       "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
@@ -9345,7 +9333,6 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -9362,7 +9349,6 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -9788,7 +9774,6 @@
       "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-5.6.4.tgz",
       "integrity": "sha512-Bkoqs+39fHwjos51qab7ZWmvZrYNBbzgSAIykH2CrgLOLhHJXzC30DP9lZq2MsmaUsbBnN5c5m8VqAhOHTrCRw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/snapshot": "^4.0.16",
         "deep-eql": "^5.0.2",
@@ -16306,7 +16291,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -20655,7 +20639,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20987,7 +20970,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21591,7 +21573,6 @@
       "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.24.0.tgz",
       "integrity": "sha512-LTJt6Z/iDM0ne/4ytd3BykoPv9CuJ+CAILOzlwFeMGn4Mj02i4Bk2Rg9o/jeJ89f52hnv4OPmNjD0e8nzWAy5g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",

--- a/packages/frontend-acceptance-tests/Dockerfile
+++ b/packages/frontend-acceptance-tests/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends wget curl gnupg git default-jdk g++ build-essential xvfb
 
 # Install google-chrome repo
-RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/google-linux-signing-keyring.gpg
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-linux-signing-keyring.gpg
 # RUN wget -q https://dl.google.com/linux/linux_signing_key.pub -O /usr/share/keyrings/google-linux-signing-keyring.gpg
 RUN /bin/sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-linux-signing-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 

--- a/packages/frontend-acceptance-tests/Dockerfile
+++ b/packages/frontend-acceptance-tests/Dockerfile
@@ -8,7 +8,8 @@ ENV TZ=Europe/London
 RUN set -ex; \
 	apt-get update; \
 	apt-get upgrade -y; \
-	apt-get install -y --no-install-recommends wget curl gnupg git default-jdk g++ build-essential xvfb
+	apt-get install -y --no-install-recommends wget curl gnupg git default-jdk g++ build-essential
+#	apt-get install -y --no-install-recommends wget curl gnupg git default-jdk g++ build-essential xvfb
 
 # Install google-chrome repo
 RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-linux-signing-keyring.gpg

--- a/packages/frontend-acceptance-tests/Dockerfile
+++ b/packages/frontend-acceptance-tests/Dockerfile
@@ -9,11 +9,9 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get upgrade -y; \
 	apt-get install -y --no-install-recommends wget curl gnupg git default-jdk g++ build-essential
-#	apt-get install -y --no-install-recommends wget curl gnupg git default-jdk g++ build-essential xvfb
 
 # Install google-chrome repo
 RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-linux-signing-keyring.gpg
-# RUN wget -q https://dl.google.com/linux/linux_signing_key.pub -O /usr/share/keyrings/google-linux-signing-keyring.gpg
 RUN /bin/sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-linux-signing-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 
 # Install Chrome

--- a/packages/frontend-acceptance-tests/Dockerfile
+++ b/packages/frontend-acceptance-tests/Dockerfile
@@ -11,7 +11,8 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends wget curl gnupg git default-jdk g++ build-essential xvfb
 
 # Install google-chrome repo
-RUN wget -q https://dl.google.com/linux/linux_signing_key.pub -O /usr/share/keyrings/google-linux-signing-keyring.gpg
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/google-linux-signing-keyring.gpg
+# RUN wget -q https://dl.google.com/linux/linux_signing_key.pub -O /usr/share/keyrings/google-linux-signing-keyring.gpg
 RUN /bin/sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-linux-signing-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 
 # Install Chrome

--- a/packages/frontend-acceptance-tests/Dockerfile
+++ b/packages/frontend-acceptance-tests/Dockerfile
@@ -11,8 +11,8 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends wget curl gnupg git default-jdk g++ build-essential xvfb
 
 # Install google-chrome repo
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN /bin/sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+RUN wget -q https://dl.google.com/linux/linux_signing_key.pub -O /usr/share/keyrings/google-linux-signing-keyring.gpg
+RUN /bin/sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-linux-signing-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 
 # Install Chrome
 RUN	apt-get update; \

--- a/packages/frontend-acceptance-tests/conf/docker.conf.js
+++ b/packages/frontend-acceptance-tests/conf/docker.conf.js
@@ -1,4 +1,5 @@
 export const config = {
+  xvfb: false,
   runner: 'local',
   specs: ['../src/features/**/*.feature'],
   maxInstances: 1,

--- a/packages/frontend-acceptance-tests/conf/docker.conf.js
+++ b/packages/frontend-acceptance-tests/conf/docker.conf.js
@@ -13,7 +13,7 @@ export const config = {
     {
       browserName: 'chrome',
       'goog:chromeOptions': {
-        args: ['--headless', '--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage']
+        args: ['--headless=new', '--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage']
       }
     }
   ],


### PR DESCRIPTION
apt-key has been removed from newer Debian/Ubuntu base images, so we need to store the GPG key as a keyring file