### PR TITLE
Remove rcp step from junior

### DIFF
--- a/packages/frontend-acceptance-tests/src/features/6 - Easy Renewals/renew_licence_expiring_yesterday.feature
+++ b/packages/frontend-acceptance-tests/src/features/6 - Easy Renewals/renew_licence_expiring_yesterday.feature
@@ -78,7 +78,6 @@ Feature: I want to renew my fishing licence
     And I am on the licence summary page and I click continue
     And I am on the contact summary page and I click continue
     And I agree to the terms and conditions and click continue
-    And I select single licence only and click continue
     And I enter payment details
     And I confirm payment details
     Then I am on the order confirmation page and exit the service


### PR DESCRIPTION
remove step to select rcp single licence from scenario 8 as angler is 16, and cannot be offered an rcp agreement until they are 17
