### PR TITLE
Handle journey differences for 17 and 18 year olds

### DIFF
--- a/packages/frontend-acceptance-tests/src/features/2 - 12 Month Licences/1_adult_licence-12-months_immediate_start.feature
+++ b/packages/frontend-acceptance-tests/src/features/2 - 12 Month Licences/1_adult_licence-12-months_immediate_start.feature
@@ -7,7 +7,7 @@ Feature: I want to buy an adult annual fishing
   Scenario: Scenario 1 - 12 Month Adult licence selecting salmon licence - Immediate start - Enter contact details
     And I am buying a licence for myself
     And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And  I enter "No" concession
     And  I select Now as a start time
     Given I select a "salmon" fishing licence
@@ -31,7 +31,7 @@ Feature: I want to buy an adult annual fishing
   Scenario: Scenario 2 - 12 Month Adult licence selecting 2 rod sea trout licence - Immediate start - Enter contact-Email
     And I am buying a licence for myself
     And I enter "Adult" "CoarseTwo" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "No" concession
     And I select Now as a start time
     Given I select a "coarse2" fishing licence
@@ -55,7 +55,7 @@ Feature: I want to buy an adult annual fishing
   Scenario: Scenario 3 - 12 Month Adult licence selecting 3 rod sea trout licence - Immediate start - By Post - NO contact
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "No" concession
     And I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -77,7 +77,7 @@ Feature: I want to buy an adult annual fishing
   Scenario: Scenario 4 - 12 Month Adult licence selecting 3 rod sea trout licence - Immediate start - By Post - Enter contact-Email
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "No" concession
     And I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -99,7 +99,7 @@ Feature: I want to buy an adult annual fishing
   Scenario: Scenario 5 - 12 Month Adult licence selecting salmon licence - Immediate start - Enter contact-Text
     And I am buying a licence for myself
     And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "No" concession
     And I select Now as a start time
     Given I select a "salmon" fishing licence
@@ -123,7 +123,7 @@ Feature: I want to buy an adult annual fishing
   Scenario: Scenario 6 - 12 Month Adult licence selecting 3 rod sea trout licence - Immediate start - By Post - Enter contact-Text
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "No" concession
     And I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -146,7 +146,7 @@ Feature: I want to buy an adult annual fishing
   Scenario: Scenario 7 - 12 Month Adult for someone else licence selecting salmon licence - Immediate start - Enter contact details
     And I am buying a licence for someone else
     And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And  I enter "No" concession
     And  I select Now as a start time
     Given I select a "salmon" fishing licence

--- a/packages/frontend-acceptance-tests/src/features/2 - 12 Month Licences/4_blue_badge_licence-12-months_immediate_start.feature
+++ b/packages/frontend-acceptance-tests/src/features/2 - 12 Month Licences/4_blue_badge_licence-12-months_immediate_start.feature
@@ -6,7 +6,7 @@ Feature: I want to buy an adult blue badge annual fishing
   Scenario: Scenario 1 - 12 Month Adult blue badge licence selecting salmon licence - Immediate start - Enter contact details
     And I am buying a licence for myself
     And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I select "BlueBadge" as the concession
     And  I select Now as a start time
     Given I select a "salmon" fishing licence
@@ -30,7 +30,7 @@ Feature: I want to buy an adult blue badge annual fishing
   Scenario: Scenario 2 - 12 Month Adult Blue Badge licence selecting 2 rod sea trout licence - Immediate start - Enter contact
     And I am buying a licence for myself
     And I enter "Adult" "CoarseTwo" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I select "BlueBadge" as the concession
     And  I select Now as a start time
     Given I select a "coarse2" fishing licence
@@ -54,7 +54,7 @@ Feature: I want to buy an adult blue badge annual fishing
   Scenario: Scenario 3 - 12 Month Adult Blue Badge licence selecting 3 rod sea trout licence - Immediate start - Enter contact-Email
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I select "BlueBadge" as the concession
     And  I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -77,7 +77,7 @@ Feature: I want to buy an adult blue badge annual fishing
   Scenario: Scenario 4 - 12 Month Adult Blue Badge licence selecting 3 rod sea trout licence - Immediate start - By Post - NO contact
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I select "BlueBadge" as the concession
     And  I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -99,7 +99,7 @@ Feature: I want to buy an adult blue badge annual fishing
   Scenario: Scenario 5 - 12 Month Adult Blue Badge licence selecting 3 rod sea trout licence - Immediate start - By Post - Enter contact- Email
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I select "BlueBadge" as the concession
     And  I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -121,7 +121,7 @@ Feature: I want to buy an adult blue badge annual fishing
   Scenario: Scenario 6 - 12 Month Adult licence selecting salmon licence - Immediate start - Enter contact-Text
     And I am buying a licence for myself
     And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I select "BlueBadge" as the concession
     And  I select Now as a start time
     Given I select a "salmon" fishing licence
@@ -145,7 +145,7 @@ Feature: I want to buy an adult blue badge annual fishing
   Scenario: Scenario 7 - 12 Month Adult licence selecting 3 rod sea trout licence - Immediate start - By Post - Enter contact-Text
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I select "BlueBadge" as the concession
     And  I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -167,7 +167,7 @@ Feature: I want to buy an adult blue badge annual fishing
   Scenario: Scenario 8 - 12 Month Adult - blue badge licence selecting salmon licence for someone else - Immediate start - Enter contact details
     And I am buying a licence for someone else
     And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I select "BlueBadge" as the concession
     And  I select Now as a start time
     Given I select a "salmon" fishing licence

--- a/packages/frontend-acceptance-tests/src/features/2 - 12 Month Licences/5_benefit_licence-12-months_immediate_start.feature
+++ b/packages/frontend-acceptance-tests/src/features/2 - 12 Month Licences/5_benefit_licence-12-months_immediate_start.feature
@@ -7,7 +7,7 @@ Feature: I want to buy an adult disabled annual fishing
   Scenario: Scenario 1 - 12 Month Adult Benefit licence selecting salmon licence - Immediate start - Enter contact details
     And I am buying a licence for myself
     And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "Benefit" as the ni concession and I enter "NP382939C" as the concesssion id
     And  I select Now as a start time
     Given I select a "salmon" fishing licence
@@ -31,7 +31,7 @@ Feature: I want to buy an adult disabled annual fishing
   Scenario: Scenario 2 - 12 Month Adult Benefit licence selecting 2 rod sea trout licence - Immediate start - Enter contact-Email
     And I am buying a licence for myself
     And I enter "Adult" "CoarseTwo" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "Benefit" as the ni concession and I enter "NP382939C" as the concesssion id
     And  I select Now as a start time
     Given I select a "coarse2" fishing licence
@@ -55,7 +55,7 @@ Feature: I want to buy an adult disabled annual fishing
   Scenario: Scenario 3 - 12 Month Adult Benefit licence selecting 3 rod sea trout licence - Immediate start - By Post - NO contact
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "Benefit" as the ni concession and I enter "NP382939C" as the concesssion id
     And  I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -77,7 +77,7 @@ Feature: I want to buy an adult disabled annual fishing
   Scenario: Scenario 4 - 12 Month Adult Benefit licence selecting 3 rod sea trout licence - Immediate start - By Post - Enter contact -Email
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "Benefit" as the ni concession and I enter "NP382939C" as the concesssion id
     And  I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -99,7 +99,7 @@ Feature: I want to buy an adult disabled annual fishing
   Scenario: Scenario 5 - 12 Month Adult licence selecting salmon licence - Immediate start - Enter contact-Text
     And I am buying a licence for myself
     And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "Benefit" as the ni concession and I enter "NP382939C" as the concesssion id
     And  I select Now as a start time
     Given I select a "salmon" fishing licence
@@ -123,7 +123,7 @@ Feature: I want to buy an adult disabled annual fishing
   Scenario: Scenario 6 - 12 Month Adult licence selecting 3 rod sea trout licence - Immediate start - By Post - Enter contact-Text
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "Benefit" as the ni concession and I enter "NP382939C" as the concesssion id
     And  I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -145,7 +145,7 @@ Feature: I want to buy an adult disabled annual fishing
   Scenario: Scenario 1 - 12 Month Adult Benefit licence  - selecting salmon licence for someone else - Immediate start - Enter contact details
     And I am buying a licence for someone else
     And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "Benefit" as the ni concession and I enter "NP382939C" as the concesssion id
     And  I select Now as a start time
     Given I select a "salmon" fishing licence

--- a/packages/frontend-acceptance-tests/src/features/2 - 12 Month Licences/6_minor_adult_licence-12-months_immediate-start.feature
+++ b/packages/frontend-acceptance-tests/src/features/2 - 12 Month Licences/6_minor_adult_licence-12-months_immediate-start.feature
@@ -1,13 +1,14 @@
-Feature: I want to buy a recurring adult blue badge annual fishing
+@browser
+Feature: I want to buy an adult annual fishing
 
-  Background: Buy an adult blue badge fishing licence
+  Background: Buy an adult fishing licence
     Given  I am at the start of the purchase journey
 
-  Scenario: Scenario 1 - 12 Month Adult blue badge licence selecting salmon licence - Immediate start - Enter contact details
+  Scenario: Scenario 1 - 12 Month Adult 17-year-old licence selecting salmon licence - Immediate start - Enter contact details
     And I am buying a licence for myself
     And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 18th birthday
-    And I select "BlueBadge" as the concession
+    And I am 7 days over my 17th birthday
+    And  I enter "No" concession
     And  I select Now as a start time
     Given I select a "salmon" fishing licence
     And I select a 12MonthLicence licence
@@ -21,19 +22,17 @@ Feature: I want to buy a recurring adult blue badge annual fishing
     And I do not want a newsletter
     And I am on the contact summary page and I click continue
     And I agree to the terms and conditions and click continue
-    And I select recurring payment and click continue
-    And I agree to set up a recurring payment and click continue
     And I enter payment details
     And I confirm payment details
-      #    Then I expect to receive a confirmation via GOV.UK Notify
+    #    Then I expect to receive a confirmation via GOV.UK Notify
     Then I am on the order confirmation page and exit the service
 
-  Scenario: Scenario 2 - 12 Month Adult Blue Badge licence selecting 2 rod sea trout licence - Immediate start - Enter contact
+  Scenario: Scenario 2 - 12 Month Adult 17-year-old licence selecting 2 rod sea trout licence - Immediate start - Enter contact-Email
     And I am buying a licence for myself
     And I enter "Adult" "CoarseTwo" as the name
-    And I am 7 days over my 18th birthday
-    And I select "BlueBadge" as the concession
-    And  I select Now as a start time
+    And I am 7 days over my 17th birthday
+    And I enter "No" concession
+    And I select Now as a start time
     Given I select a "coarse2" fishing licence
     And I select a 12MonthLicence licence
     Then I am on the licence summary page and I click continue
@@ -46,43 +45,17 @@ Feature: I want to buy a recurring adult blue badge annual fishing
     And I do not want a newsletter
     And I am on the contact summary page and I click continue
     And I agree to the terms and conditions and click continue
-    And I select recurring payment and click continue
-    And I agree to set up a recurring payment and click continue
     And I enter payment details
     And I confirm payment details
     #    Then I expect to receive a confirmation via GOV.UK Notify
     Then I am on the order confirmation page and exit the service
 
-  Scenario: Scenario 3 - 12 Month Adult Blue Badge licence selecting 3 rod sea trout licence - Immediate start - Enter contact-Email
+  Scenario: Scenario 3 - 12 Month Adult 17-year-old licence selecting 3 rod sea trout licence - Immediate start - By Post - NO contact
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 18th birthday
-    And I select "BlueBadge" as the concession
-    And  I select Now as a start time
-    Given I select a "coarse3" fishing licence
-    Then I am on the licence summary page and I click continue
-    And I enter "3" and "SN153PG" as my house number and postcode
-    And I select "100121002711" as an address
-    And I select digital license
-    And I enter email as "email@example.com" and number as "" for confirmation method
-    And I am on the confirm contact details page and it asks me to confirm my email address and I click correct
-    And I click email radio button and click continue
-    And I do not want a newsletter
-    And I am on the contact summary page and I click continue
-    And I agree to the terms and conditions and click continue
-    And I select recurring payment and click continue
-    And I agree to set up a recurring payment and click continue
-    And I enter payment details
-    And I confirm payment details
-    #    Then I expect to receive a confirmation via GOV.UK Notify
-    Then I am on the order confirmation page and exit the service
-
-  Scenario: Scenario 4 - 12 Month Adult Blue Badge licence selecting 3 rod sea trout licence - Immediate start - By Post - NO contact
-    And I am buying a licence for myself
-    And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 18th birthday
-    And I select "BlueBadge" as the concession
-    And  I select Now as a start time
+    And I am 7 days over my 17th birthday
+    And I enter "No" concession
+    And I select Now as a start time
     Given I select a "coarse3" fishing licence
     Then I am on the licence summary page and I click continue
     And I enter "3" and "SN153PG" as my house number and postcode
@@ -93,19 +66,17 @@ Feature: I want to buy a recurring adult blue badge annual fishing
     And I do not want a newsletter
     And I am on the contact summary page and I click continue
     And I agree to the terms and conditions and click continue
-    And I select recurring payment and click continue
-    And I agree to set up a recurring payment and click continue
-    And I enter payment details and email
+    And I enter payment details
     And I confirm payment details
     #    Then I expect to receive a confirmation via GOV.UK Notify
     Then I am on the order confirmation page and exit the service
 
-  Scenario: Scenario 5 - 12 Month Adult Blue Badge licence selecting 3 rod sea trout licence - Immediate start - By Post - Enter contact- Email
+  Scenario: Scenario 4 - 12 Month Adult 17-year-old licence selecting 3 rod sea trout licence - Immediate start - By Post - Enter contact-Email
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 18th birthday
-    And I select "BlueBadge" as the concession
-    And  I select Now as a start time
+    And I am 7 days over my 17th birthday
+    And I enter "No" concession
+    And I select Now as a start time
     Given I select a "coarse3" fishing licence
     Then I am on the licence summary page and I click continue
     And I enter "3" and "SN153PG" as my house number and postcode
@@ -116,19 +87,17 @@ Feature: I want to buy a recurring adult blue badge annual fishing
     And I do not want a newsletter
     And I am on the contact summary page and I click continue
     And I agree to the terms and conditions and click continue
-    And I select recurring payment and click continue
-    And I agree to set up a recurring payment and click continue
     And I enter payment details
     And I confirm payment details
     #    Then I expect to receive a confirmation via GOV.UK Notify
     Then I am on the order confirmation page and exit the service
 
-  Scenario: Scenario 6 - 12 Month Adult licence selecting salmon licence - Immediate start - Enter contact-Text
+  Scenario: Scenario 5 - 12 Month Adult 17-year-old licence selecting salmon licence - Immediate start - Enter contact-Text
     And I am buying a licence for myself
     And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 18th birthday
-    And I select "BlueBadge" as the concession
-    And  I select Now as a start time
+    And I am 7 days over my 17th birthday
+    And I enter "No" concession
+    And I select Now as a start time
     Given I select a "salmon" fishing licence
     And I select a 12MonthLicence licence
     Then I am on the licence summary page and I click continue
@@ -141,21 +110,20 @@ Feature: I want to buy a recurring adult blue badge annual fishing
     And I do not want a newsletter
     And I am on the contact summary page and I click continue
     And I agree to the terms and conditions and click continue
-    And I select recurring payment and click continue
-    And I agree to set up a recurring payment and click continue
-    And I enter payment details and email
+    And I enter payment details
     And I confirm payment details
     #    Then I expect to receive a confirmation via GOV.UK Notify
     Then I am on the order confirmation page and exit the service
 
-  Scenario: Scenario 7 - 12 Month Adult licence selecting 3 rod sea trout licence - Immediate start - By Post - Enter contact-Text
+  Scenario: Scenario 6 - 12 Month Adult 17-year-old licence selecting 3 rod sea trout licence - Immediate start - By Post - Enter contact-Text
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 18th birthday
-    And I select "BlueBadge" as the concession
-    And  I select Now as a start time
+    And I am 7 days over my 17th birthday
+    And I enter "No" concession
+    And I select Now as a start time
     Given I select a "coarse3" fishing licence
     Then I am on the licence summary page and I click continue
+  # Contact Journey starts
     And I enter "3" and "SN153PG" as my house number and postcode
     And I select "100121002711" as an address
     And I select paper license
@@ -164,10 +132,28 @@ Feature: I want to buy a recurring adult blue badge annual fishing
     And I do not want a newsletter
     And I am on the contact summary page and I click continue
     And I agree to the terms and conditions and click continue
-    And I select recurring payment and click continue
-    And I agree to set up a recurring payment and click continue
-    And I enter payment details and email
+    And I enter payment details
     And I confirm payment details
     #    Then I expect to receive a confirmation via GOV.UK Notify
     Then I am on the order confirmation page and exit the service
 
+  Scenario: Scenario 7 - 12 Month Adult 17-year-old for someone else licence selecting salmon licence - Immediate start - Enter contact details
+    And I am buying a licence for someone else
+    And I enter "Adult" "Salmon" as the name
+    And I am 7 days over my 17th birthday
+    And  I enter "No" concession
+    And  I select Now as a start time
+    Given I select a "salmon" fishing licence
+    And I select a 12MonthLicence licence
+    Then I am on the licence summary page and I click continue
+    And I enter "3" and "SN153PG" as my house number and postcode
+    And I select "100121002711" as an address
+    And I select digital license
+    And I enter email as "email@example.com" and number as "" for confirmation method
+    And I am on the confirm contact details page and it asks me to confirm my email address and I click correct
+    And I click email radio button and click continue
+    And I am on the contact summary page and I click continue
+    And I agree to the terms and conditions and click continue
+    And I enter payment and address details
+    And I confirm payment details
+    Then I am on the order confirmation page and exit the service

--- a/packages/frontend-acceptance-tests/src/features/2 - 12 Month Licences/6_minor_adult_licence-12-months_immediate-start.feature
+++ b/packages/frontend-acceptance-tests/src/features/2 - 12 Month Licences/6_minor_adult_licence-12-months_immediate-start.feature
@@ -1,7 +1,7 @@
 @browser
-Feature: I want to buy an adult annual fishing
+Feature: I want to buy an adult annual fishing licence as a 17 year old
 
-  Background: Buy an adult fishing licence
+  Background: Buy an adult fishing licence as a 17 year old
     Given  I am at the start of the purchase journey
 
   Scenario: Scenario 1 - 12 Month Adult 17-year-old licence selecting salmon licence - Immediate start - Enter contact details

--- a/packages/frontend-acceptance-tests/src/features/3 - Negative Tests/1_adult_licence_12_NEG.feature
+++ b/packages/frontend-acceptance-tests/src/features/3 - Negative Tests/1_adult_licence_12_NEG.feature
@@ -58,7 +58,7 @@ Scenario: Scenario 1 - Licence For, Name and DOB Errors
     Then I expect the dob page to show the following errors
       | ErrorMessage  |
       | The date of birth must be in the past  |
-    *   I am 7 days over my 17th birthday
+    *   I am 7 days over my 18th birthday
 
 
 Scenario: Scenario 2 - Concession Errors

--- a/packages/frontend-acceptance-tests/src/features/4- GovPay/1_gov_pay.feature
+++ b/packages/frontend-acceptance-tests/src/features/4- GovPay/1_gov_pay.feature
@@ -5,7 +5,7 @@ Feature: I want to buy a 1 or 8 day licence adult fishing licence
     Given  I am at the start of the purchase journey
     And I am buying a licence for myself
     And I enter "<firstName>" "<lastName>" as the name
-    *   I am 1 day over my 17th birthday
+    *   I am 1 day over my 18th birthday
     *   I enter "<concession>" concession
     And  I select <startFrom> as a start time
     And I select a "<licenceType>" fishing licence

--- a/packages/frontend-acceptance-tests/src/features/5 - Notify/1_NOTIFY_adult_licence-12-months_immediate_start.feature
+++ b/packages/frontend-acceptance-tests/src/features/5 - Notify/1_NOTIFY_adult_licence-12-months_immediate_start.feature
@@ -8,7 +8,7 @@ Feature: I want to buy an adult annual fishing - NOTIFY
 
   Scenario: Scenario 1 - 12 Month Adult licence selecting salmon licence - Immediate start - Enter contact details
     And I enter "Adult" "Salmon" as the name
-    *   I am 7 days over my 17th birthday
+    *   I am 7 days over my 18th birthday
     *   I enter "No" concession
     And  I select Now as a start time
     Given I select a "salmon" fishing licence
@@ -32,7 +32,7 @@ Feature: I want to buy an adult annual fishing - NOTIFY
   Scenario: Scenario 2 - 12 Month Adult licence selecting 2 rod sea trout licence - Immediate start - Enter contact-Email
 # Licence details journey starts
     And I enter "Adult" "CoarseTwo" as the name
-    *   I am 7 days over my 17th birthday
+    *   I am 7 days over my 18th birthday
     *   I enter "No" concession
     And  I select Now as a start time
     Given I select a "coarse2" fishing licence
@@ -57,7 +57,7 @@ Feature: I want to buy an adult annual fishing - NOTIFY
   Scenario: Scenario 3 - 12 Month Adult licence selecting 3 rod sea trout licence - Immediate start - NO contact
  # Licence details journey starts
     And I enter "Adult" "CoarseThree" as the name
-    *   I am 7 days over my 17th birthday
+    *   I am 7 days over my 18th birthday
     *   I enter "No" concession
     And  I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -66,7 +66,7 @@ Feature: I want to buy an adult annual fishing - NOTIFY
     And I enter "3" and "SN153PG" as my house number and postcode
     And I select "100121002711" as an address
     And I select paper license
-    And I select make a note of the license 
+    And I select make a note of the license
     And I do not have either of these
     And I do not want a newsletter
     And I am on the contact summary page and I click continue
@@ -80,7 +80,7 @@ Feature: I want to buy an adult annual fishing - NOTIFY
   Scenario: Scenario 3 - 12 Month Adult licence selecting 2 rod sea trout licence - Immediate start - Enter contact-Text
 # Licence details journey starts
     And I enter "Adult" "CoarseTwo" as the name
-    *   I am 7 days over my 17th birthday
+    *   I am 7 days over my 18th birthday
     *   I enter "No" concession
     And  I select Now as a start time
     Given I select a "coarse2" fishing licence

--- a/packages/frontend-acceptance-tests/src/features/6 - Easy Renewals/renew_licence_expiring_yesterday.feature
+++ b/packages/frontend-acceptance-tests/src/features/6 - Easy Renewals/renew_licence_expiring_yesterday.feature
@@ -103,7 +103,7 @@ Feature: I want to renew my fishing licence
     Then I am on the order confirmation page and exit the service
 
   Scenario: Scenario 11 - Renew my adult licence that expires today as an 18 year old on my birthday
-    Given I am at the start of the renewal journey with a "Coarse 12 month 2 Rod Licence (Adult)" licence, that expires in 0 days and I am 0 days over my 18th birthday and my name is "Lisa" "SimpsonRenewal"
+    Given I am at the start of the renewal journey with a "Coarse 12 month 2 Rod Licence (Full)" licence, that expires in 0 days and I am 0 days over my 18th birthday and my name is "Lisa" "SimpsonRenewal"
     And I enter "SN153PG" as the postcode and click continue
     And I am on the licence summary page and I click continue
     And I am on the contact summary page and I click continue

--- a/packages/frontend-acceptance-tests/src/features/6 - Easy Renewals/renew_licence_expiring_yesterday.feature
+++ b/packages/frontend-acceptance-tests/src/features/6 - Easy Renewals/renew_licence_expiring_yesterday.feature
@@ -88,6 +88,26 @@ Feature: I want to renew my fishing licence
     And I am on the licence summary page and I click continue
     And I am on the contact summary page and I click continue
     And I agree to the terms and conditions and click continue
+    And I enter payment details
+    And I confirm payment details
+    Then I am on the order confirmation page and exit the service
+
+  Scenario: Scenario 10 - Renew my adult licence that expires in two days as a 17 year old on the day before my 18th birthday
+    Given I am at the start of the renewal journey with a "Coarse 12 month 2 Rod Licence (Full)" licence, that expires in 2 days and I am 1 days under my 18th birthday and my name is "Lisa" "SimpsonRenewal"
+    And I enter "SN153PG" as the postcode and click continue
+    And I am on the licence summary page and I click continue
+    And I am on the contact summary page and I click continue
+    And I agree to the terms and conditions and click continue
+    And I enter payment details
+    And I confirm payment details
+    Then I am on the order confirmation page and exit the service
+
+  Scenario: Scenario 11 - Renew my adult licence that expires today as an 18 year old on my birthday
+    Given I am at the start of the renewal journey with a "Coarse 12 month 2 Rod Licence (Adult)" licence, that expires in 0 days and I am 0 days over my 18th birthday and my name is "Lisa" "SimpsonRenewal"
+    And I enter "SN153PG" as the postcode and click continue
+    And I am on the licence summary page and I click continue
+    And I am on the contact summary page and I click continue
+    And I agree to the terms and conditions and click continue
     And I select single licence only and click continue
     And I enter payment details
     And I confirm payment details

--- a/packages/frontend-acceptance-tests/src/features/8 - Recurring Payments/1_adult_licence-12-months_immediate_start_recurring.feature
+++ b/packages/frontend-acceptance-tests/src/features/8 - Recurring Payments/1_adult_licence-12-months_immediate_start_recurring.feature
@@ -148,26 +148,3 @@ Feature: I want to buy a recurring adult annual fishing
     And I confirm payment details
     #    Then I expect to receive a confirmation via GOV.UK Notify
     Then I am on the order confirmation page and exit the service
-
-  Scenario: Scenario 7 - 12 Month Adult licence 17 year old selecting salmon licence - Immediate start - Enter contact details
-    And I am buying a licence for myself
-    And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 17th birthday
-    And  I enter "No" concession
-    And  I select Now as a start time
-    Given I select a "salmon" fishing licence
-    And I select a 12MonthLicence licence
-    Then I am on the licence summary page and I click continue
-    And I enter "3" and "SN153PG" as my house number and postcode
-    And I select "100121002711" as an address
-    And I select digital license
-    And I enter email as "email@example.com" and number as "" for confirmation method
-    And I am on the confirm contact details page and it asks me to confirm my email address and I click correct
-    And I click email radio button and click continue
-    And I do not want a newsletter
-    And I am on the contact summary page and I click continue
-    And I agree to the terms and conditions and click continue
-    And I enter payment details
-    And I confirm payment details
-    #    Then I expect to receive a confirmation via GOV.UK Notify
-    Then I am on the order confirmation page and exit the service

--- a/packages/frontend-acceptance-tests/src/features/8 - Recurring Payments/1_adult_licence-12-months_immediate_start_recurring.feature
+++ b/packages/frontend-acceptance-tests/src/features/8 - Recurring Payments/1_adult_licence-12-months_immediate_start_recurring.feature
@@ -7,7 +7,7 @@ Feature: I want to buy a recurring adult annual fishing
   Scenario: Scenario 1 - 12 Month Adult licence selecting salmon licence - Immediate start - Enter contact details
     And I am buying a licence for myself
     And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And  I enter "No" concession
     And  I select Now as a start time
     Given I select a "salmon" fishing licence
@@ -32,7 +32,7 @@ Feature: I want to buy a recurring adult annual fishing
   Scenario: Scenario 2 - 12 Month Adult licence selecting 2 rod sea trout licence - Immediate start - Enter contact-Email
     And I am buying a licence for myself
     And I enter "Adult" "CoarseTwo" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "No" concession
     And I select Now as a start time
     Given I select a "coarse2" fishing licence
@@ -57,7 +57,7 @@ Feature: I want to buy a recurring adult annual fishing
   Scenario: Scenario 3 - 12 Month Adult licence selecting 3 rod sea trout licence - Immediate start - By Post - NO contact
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "No" concession
     And I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -80,7 +80,7 @@ Feature: I want to buy a recurring adult annual fishing
   Scenario: Scenario 4 - 12 Month Adult licence selecting 3 rod sea trout licence - Immediate start - By Post - Enter contact-Email
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "No" concession
     And I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -103,7 +103,7 @@ Feature: I want to buy a recurring adult annual fishing
   Scenario: Scenario 5 - 12 Month Adult licence selecting salmon licence - Immediate start - Enter contact-Text
     And I am buying a licence for myself
     And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "No" concession
     And I select Now as a start time
     Given I select a "salmon" fishing licence
@@ -128,7 +128,7 @@ Feature: I want to buy a recurring adult annual fishing
   Scenario: Scenario 6 - 12 Month Adult licence selecting 3 rod sea trout licence - Immediate start - By Post - Enter contact-Text
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "No" concession
     And I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -145,6 +145,29 @@ Feature: I want to buy a recurring adult annual fishing
     And I select recurring payment and click continue
     And I agree to set up a recurring payment and click continue
     And I enter payment details and email
+    And I confirm payment details
+    #    Then I expect to receive a confirmation via GOV.UK Notify
+    Then I am on the order confirmation page and exit the service
+
+  Scenario: Scenario 7 - 12 Month Adult licence 17 year old selecting salmon licence - Immediate start - Enter contact details
+    And I am buying a licence for myself
+    And I enter "Adult" "Salmon" as the name
+    And I am 7 days over my 17th birthday
+    And  I enter "No" concession
+    And  I select Now as a start time
+    Given I select a "salmon" fishing licence
+    And I select a 12MonthLicence licence
+    Then I am on the licence summary page and I click continue
+    And I enter "3" and "SN153PG" as my house number and postcode
+    And I select "100121002711" as an address
+    And I select digital license
+    And I enter email as "email@example.com" and number as "" for confirmation method
+    And I am on the confirm contact details page and it asks me to confirm my email address and I click correct
+    And I click email radio button and click continue
+    And I do not want a newsletter
+    And I am on the contact summary page and I click continue
+    And I agree to the terms and conditions and click continue
+    And I enter payment details
     And I confirm payment details
     #    Then I expect to receive a confirmation via GOV.UK Notify
     Then I am on the order confirmation page and exit the service

--- a/packages/frontend-acceptance-tests/src/features/8 - Recurring Payments/4_benefit_licence-12-months_immediate_start_recurring.feature
+++ b/packages/frontend-acceptance-tests/src/features/8 - Recurring Payments/4_benefit_licence-12-months_immediate_start_recurring.feature
@@ -7,7 +7,7 @@ Feature: I want to buy a recurring adult disabled annual fishing
   Scenario: Scenario 1 - 12 Month Adult Benefit licence selecting salmon licence - Immediate start - Enter contact details
     And I am buying a licence for myself
     And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "Benefit" as the ni concession and I enter "NP382939C" as the concesssion id
     And  I select Now as a start time
     Given I select a "salmon" fishing licence
@@ -32,7 +32,7 @@ Feature: I want to buy a recurring adult disabled annual fishing
   Scenario: Scenario 2 - 12 Month Adult Benefit licence selecting 2 rod sea trout licence - Immediate start - Enter contact-Email
     And I am buying a licence for myself
     And I enter "Adult" "CoarseTwo" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "Benefit" as the ni concession and I enter "NP382939C" as the concesssion id
     And  I select Now as a start time
     Given I select a "coarse2" fishing licence
@@ -57,7 +57,7 @@ Feature: I want to buy a recurring adult disabled annual fishing
   Scenario: Scenario 3 - 12 Month Adult Benefit licence selecting 3 rod sea trout licence - Immediate start - By Post - NO contact
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "Benefit" as the ni concession and I enter "NP382939C" as the concesssion id
     And  I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -80,7 +80,7 @@ Feature: I want to buy a recurring adult disabled annual fishing
   Scenario: Scenario 4 - 12 Month Adult Benefit licence selecting 3 rod sea trout licence - Immediate start - By Post - Enter contact -Email
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "Benefit" as the ni concession and I enter "NP382939C" as the concesssion id
     And  I select Now as a start time
     Given I select a "coarse3" fishing licence
@@ -103,7 +103,7 @@ Feature: I want to buy a recurring adult disabled annual fishing
   Scenario: Scenario 5 - 12 Month Adult licence selecting salmon licence - Immediate start - Enter contact-Text
     And I am buying a licence for myself
     And I enter "Adult" "Salmon" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "Benefit" as the ni concession and I enter "NP382939C" as the concesssion id
     And  I select Now as a start time
     Given I select a "salmon" fishing licence
@@ -128,7 +128,7 @@ Feature: I want to buy a recurring adult disabled annual fishing
   Scenario: Scenario 6 - 12 Month Adult licence selecting 3 rod sea trout licence - Immediate start - By Post - Enter contact-Text
     And I am buying a licence for myself
     And I enter "Adult" "CoarseThree" as the name
-    And I am 7 days over my 17th birthday
+    And I am 7 days over my 18th birthday
     And I enter "Benefit" as the ni concession and I enter "NP382939C" as the concesssion id
     And  I select Now as a start time
     Given I select a "coarse3" fishing licence


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWTF-5168

We are no longer offering recurring payments to 17 year olds. This means that the adult licence journey is now slightly different for 17 year olds than it is for 18 and up.

I've dealt with this by changing our 1-year adult licence tests to 18 by default, plus adding an extra file for 12 month licences specifically for 17 year olds, and adding some additional tests to easy renewals to make sure users see the correct pages for their age.